### PR TITLE
Fix camera being too close to player

### DIFF
--- a/src/main/java/thunder/hack/injection/MixinCamera.java
+++ b/src/main/java/thunder/hack/injection/MixinCamera.java
@@ -16,7 +16,9 @@ public abstract class MixinCamera {
 
     @ModifyArgs(method = "update", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/Camera;moveBy(DDD)V", ordinal = 0))
     private void modifyCameraDistance(Args args) {
-        args.set(0, -clipToSpace(ModuleManager.noCameraClip.getDistance()));
+        if (ModuleManager.noCameraClip.isEnabled()) {
+            args.set(0, -clipToSpace(ModuleManager.noCameraClip.getDistance()));
+        }
     }
 
     @Inject(method = "clipToSpace", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/thunder/hack/modules/render/NameTags.java
+++ b/src/main/java/thunder/hack/modules/render/NameTags.java
@@ -348,13 +348,12 @@ public class NameTags extends Module {
     }
 
     public void drawPotions(MatrixStack matrices, @NotNull PlayerEntity entity, float posX, float posY) {
-        ArrayList<StatusEffectInstance> effects = new ArrayList<>();
+        ArrayList<StatusEffectInstance> effects = new ArrayList<>(entity.getStatusEffects());
 
         int y_offset1 = 0;
 
-        for (StatusEffectInstance potionEffect : entity.getStatusEffects()) {
+        for (StatusEffectInstance potionEffect : effects) {
             if (potionEffect.getDuration() != 0) {
-                effects.add(potionEffect);
                 StatusEffect potion = potionEffect.getEffectType();
                 String power = "";
                 switch (potionEffect.getAmplifier()) {
@@ -365,7 +364,7 @@ public class NameTags extends Module {
                     case 4 -> power = "V";
                 }
                 String s = potion.getName().getString() + " " + power;
-                String s2 = getDuration(potionEffect) + "";
+                String s2 = getDuration(potionEffect);
 
                 FontRenderers.sf_bold_mini.drawString(matrices, s + " " + s2, posX, posY + y_offset1, -1);
                 y_offset1 += 8;


### PR DESCRIPTION
This PR fixes a bug where the distance of the camera to the player in third person was set even if NoCameraClip was off