### PR TITLE
Remove debug print

### DIFF
--- a/src/main/java/thunder/hack/modules/combat/AutoCrystal.java
+++ b/src/main/java/thunder/hack/modules/combat/AutoCrystal.java
@@ -260,7 +260,7 @@ public class AutoCrystal extends Module {
             boolean hitVisible = bestCrystal == null || PlayerUtility.canSee(bestCrystal.getPos());
             boolean placeVisible = bestPosition == null || PlayerUtility.canSee(bestPosition.getPos());
 
-            sendMessage(hitVisible + " " + placeVisible);
+            debug("hit:"hitVisible + ", place:" + placeVisible);
 
             if (mc.player.age % 5 == 0 && rayTraceBypass.getValue() && (!hitVisible || !placeVisible)) mc.player.setPitch(-90);
             else mc.player.setPitch(rotationPitch);


### PR DESCRIPTION
In commit f52c759 there was a debug statement introduced on line 263 of AutoCrystal.java, using the sendMessage() function. Usually such debug statements are made using the debug() function, which doesn't send the message if the user has disabled debug logging. 

This PR changes it to the proper function, so the chat of users isn't flooded by log messages.

**Note:** I didn't test this yet in minecraft, so someone should do that before merging.

Example of a users chat getting flooded:
![image](https://github.com/Pan4ur/ThunderHack-Recode/assets/125088775/e574de35-8990-4755-a304-3c04e1581b92)

