### PR TITLE
Wayland (Linux): Catch error when setting Window Icon

### DIFF
--- a/src/main/java/thunder/hack/injection/MixinMinecraftClient.java
+++ b/src/main/java/thunder/hack/injection/MixinMinecraftClient.java
@@ -172,7 +172,9 @@ public abstract class MixinMinecraftClient {
                 buffers.add(bytebuffer);
             }
 
-            GLFW.glfwSetWindowIcon(mc.getWindow().getHandle(), buffer);
+            try {
+                GLFW.glfwSetWindowIcon(mc.getWindow().getHandle(), buffer);
+            } catch (Exception ignored) {}
             buffers.forEach(MemoryUtil::memFree);
         } catch (IOException ignored) {
         }


### PR DESCRIPTION
When launching the client with a Wayland supported GLFW build on Plasma, it will show a error trying to set the window icon, because Plasma doesn't support the new Window icon protocol yet (not sure how it is on GLFW side).
![image](https://github.com/Pan4ur/ThunderHack-Recode/assets/57004660/52ba8713-953b-47b6-8910-ed212ca66296)
Clicking "OK" in this prompt will result in the client stalling and never starting. With this PR the error still persists, but when clicking on "OK" the game will start immediately after.
