### PR TITLE
Check for Wayland platform

### DIFF
--- a/src/main/java/thunder/hack/core/impl/ModuleManager.java
+++ b/src/main/java/thunder/hack/core/impl/ModuleManager.java
@@ -328,11 +328,13 @@ public class ModuleManager implements IManager {
     }
 
     public void onRender2D(DrawContext context) {
-        if(mc.getDebugHud().shouldShowDebugHud() || mc.options.hudHidden) return;
+        if (mc.getDebugHud().shouldShowDebugHud() || mc.options.hudHidden) return;
         HudElement.anyHovered = false;
         modules.stream().filter(Module::isEnabled).forEach(module -> module.onRender2D(context));
         if (!HudElement.anyHovered && !ClickGUI.anyHovered)
-            GLFW.glfwSetCursor(mc.getWindow().getHandle(), GLFW.glfwCreateStandardCursor(GLFW.GLFW_ARROW_CURSOR));
+            if (GLFW.glfwGetPlatform() != GLFW.GLFW_PLATFORM_WAYLAND) {
+                GLFW.glfwSetCursor(mc.getWindow().getHandle(), GLFW.glfwCreateStandardCursor(GLFW.GLFW_ARROW_CURSOR));
+            }
         ThunderHack.core.onRender2D(context);
     }
 

--- a/src/main/java/thunder/hack/gui/clickui/ClickGUI.java
+++ b/src/main/java/thunder/hack/gui/clickui/ClickGUI.java
@@ -212,7 +212,9 @@ public class ClickGUI extends Screen {
                             "\nDelete + Left Mouse Click on module to reset", 5, mc.getWindow().getScaledHeight() - 80, HudEditor.getColor(0).getRGB());
 
         if (!HudElement.anyHovered && !ClickGUI.anyHovered)
-            GLFW.glfwSetCursor(mc.getWindow().getHandle(), GLFW.glfwCreateStandardCursor(GLFW.GLFW_ARROW_CURSOR));
+            if (GLFW.glfwGetPlatform() != GLFW.GLFW_PLATFORM_WAYLAND) {
+                GLFW.glfwSetCursor(mc.getWindow().getHandle(), GLFW.glfwCreateStandardCursor(GLFW.GLFW_ARROW_CURSOR));
+            }
     }
 
     @Override

--- a/src/main/java/thunder/hack/gui/clickui/impl/BooleanElement.java
+++ b/src/main/java/thunder/hack/gui/clickui/impl/BooleanElement.java
@@ -42,9 +42,11 @@ public class BooleanElement extends AbstractElement {
             FontRenderers.sf_bold_mini.drawString(context.getMatrices(), "x", x + width - 12f, y + height / 2 - 2f, new Color(-1).getRGB());
         }
 
-        if(Render2DEngine.isHovered(mouseX, mouseY, x + width - 21, y + height / 2 - 4, 15, 8)) {
-            GLFW.glfwSetCursor(mc.getWindow().getHandle(),
-                    GLFW.glfwCreateStandardCursor(GLFW.GLFW_HAND_CURSOR));
+        if (Render2DEngine.isHovered(mouseX, mouseY, x + width - 21, y + height / 2 - 4, 15, 8)) {
+            if (GLFW.glfwGetPlatform() != GLFW.GLFW_PLATFORM_WAYLAND) {
+                GLFW.glfwSetCursor(mc.getWindow().getHandle(),
+                        GLFW.glfwCreateStandardCursor(GLFW.GLFW_HAND_CURSOR));
+            }
             ClickGUI.anyHovered = true;
         }
 

--- a/src/main/java/thunder/hack/gui/clickui/impl/BooleanParentElement.java
+++ b/src/main/java/thunder/hack/gui/clickui/impl/BooleanParentElement.java
@@ -62,9 +62,11 @@ public class BooleanParentElement extends AbstractElement {
             FontRenderers.sf_bold_mini.drawString(context.getMatrices(), "x", x + width - 27f, y + height / 2 - 2f, new Color(-1).getRGB());
         }
 
-        if(Render2DEngine.isHovered(mouseX, mouseY, x + width - 36, y + height / 2 - 4, 15, 8)) {
-            GLFW.glfwSetCursor(mc.getWindow().getHandle(),
-                    GLFW.glfwCreateStandardCursor(GLFW.GLFW_HAND_CURSOR));
+        if (Render2DEngine.isHovered(mouseX, mouseY, x + width - 36, y + height / 2 - 4, 15, 8)) {
+            if (GLFW.glfwGetPlatform() != GLFW.GLFW_PLATFORM_WAYLAND) {
+                GLFW.glfwSetCursor(mc.getWindow().getHandle(),
+                        GLFW.glfwCreateStandardCursor(GLFW.GLFW_HAND_CURSOR));
+            }
             ClickGUI.anyHovered = true;
         }
     }

--- a/src/main/java/thunder/hack/gui/clickui/impl/SearchBar.java
+++ b/src/main/java/thunder/hack/gui/clickui/impl/SearchBar.java
@@ -26,8 +26,10 @@ public class SearchBar extends AbstractButton {
             FontRenderers.sf_medium.drawGradientString(context.getMatrices(), moduleName + (mc.player == null || ((mc.player.age / 10) % 2 == 0) ? " " : "_"), x + 7f, y + 5f, 2);
 
         if (Render2DEngine.isHovered(mouseX, mouseY, x, y, width, height)) {
-            GLFW.glfwSetCursor(mc.getWindow().getHandle(),
-                    GLFW.glfwCreateStandardCursor(GLFW.GLFW_IBEAM_CURSOR));
+            if (GLFW.glfwGetPlatform() != GLFW.GLFW_PLATFORM_WAYLAND) {
+                GLFW.glfwSetCursor(mc.getWindow().getHandle(),
+                        GLFW.glfwCreateStandardCursor(GLFW.GLFW_IBEAM_CURSOR));
+            }
             ClickGUI.anyHovered = true;
         }
     }

--- a/src/main/java/thunder/hack/gui/clickui/impl/SliderElement.java
+++ b/src/main/java/thunder/hack/gui/clickui/impl/SliderElement.java
@@ -66,8 +66,10 @@ public class SliderElement extends AbstractElement {
             setValue(mouseX, x + 7, width - 14);
 
         if (Render2DEngine.isHovered(mouseX, mouseY, (x + 6), y + height - 7, width - 12, 3)) {
-            GLFW.glfwSetCursor(mc.getWindow().getHandle(),
-                    GLFW.glfwCreateStandardCursor(GLFW.GLFW_HRESIZE_CURSOR));
+            if (GLFW.glfwGetPlatform() != GLFW.GLFW_PLATFORM_WAYLAND) {
+                GLFW.glfwSetCursor(mc.getWindow().getHandle(),
+                        GLFW.glfwCreateStandardCursor(GLFW.GLFW_HRESIZE_CURSOR));
+            }
             ClickGUI.anyHovered = true;
         }
     }
@@ -145,7 +147,8 @@ public class SliderElement extends AbstractElement {
             String k = ".";
             try {
                 k = String.valueOf(Integer.parseInt(String.valueOf(key)));
-            } catch (Exception ignored) {}
+            } catch (Exception ignored) {
+            }
             Stringnumber = Stringnumber + k;
         }
     }

--- a/src/main/java/thunder/hack/gui/clickui/impl/StringElement.java
+++ b/src/main/java/thunder/hack/gui/clickui/impl/StringElement.java
@@ -31,9 +31,11 @@ public class StringElement extends AbstractElement {
         Render2DEngine.drawRect(context.getMatrices(), getX() + 5, getY() + 2, getWidth() - 11f, 10, new Color(0x94000000, true));
         FontRenderers.sf_medium_mini.drawString(context.getMatrices(), listening ? currentString + (mc.player == null || mc.player.age % 5 == 0 ? "_" : "") : (String) setting.getValue(), x + 6, y + height / 2, -1);
 
-        if(Render2DEngine.isHovered(mouseX, mouseY, getX() + 5, getY() + 2, getWidth() - 11f, 10)) {
-            GLFW.glfwSetCursor(mc.getWindow().getHandle(),
-                    GLFW.glfwCreateStandardCursor(GLFW.GLFW_IBEAM_CURSOR));
+        if (Render2DEngine.isHovered(mouseX, mouseY, getX() + 5, getY() + 2, getWidth() - 11f, 10)) {
+            if (GLFW.glfwGetPlatform() != GLFW.GLFW_PLATFORM_WAYLAND) {
+                GLFW.glfwSetCursor(mc.getWindow().getHandle(),
+                        GLFW.glfwCreateStandardCursor(GLFW.GLFW_IBEAM_CURSOR));
+            }
             ClickGUI.anyHovered = true;
         }
     }

--- a/src/main/java/thunder/hack/gui/hud/HudElement.java
+++ b/src/main/java/thunder/hack/gui/hud/HudElement.java
@@ -83,7 +83,9 @@ public class HudElement extends Module {
         }
 
         if (isHovering() && (mc.currentScreen instanceof ChatScreen || mc.currentScreen instanceof HudEditorGui)) {
-            GLFW.glfwSetCursor(mc.getWindow().getHandle(), mouseState ? GLFW.glfwCreateStandardCursor(GLFW.GLFW_CROSSHAIR_CURSOR) : GLFW.glfwCreateStandardCursor(GLFW.GLFW_HAND_CURSOR));
+            if (GLFW.glfwGetPlatform() != GLFW.GLFW_PLATFORM_WAYLAND) {
+                GLFW.glfwSetCursor(mc.getWindow().getHandle(), mouseState ? GLFW.glfwCreateStandardCursor(GLFW.GLFW_CROSSHAIR_CURSOR) : GLFW.glfwCreateStandardCursor(GLFW.GLFW_HAND_CURSOR));
+            }
             anyHovered = true;
         }
 

--- a/src/main/java/thunder/hack/injection/MixinMinecraftClient.java
+++ b/src/main/java/thunder/hack/injection/MixinMinecraftClient.java
@@ -173,8 +173,11 @@ public abstract class MixinMinecraftClient {
             }
 
             try {
-                GLFW.glfwSetWindowIcon(mc.getWindow().getHandle(), buffer);
-            } catch (Exception ignored) {}
+                if (GLFW.glfwGetPlatform() != GLFW.GLFW_PLATFORM_WAYLAND) {
+                    GLFW.glfwSetWindowIcon(mc.getWindow().getHandle(), buffer);
+                }
+            } catch (Exception ignored) {
+            }
             buffers.forEach(MemoryUtil::memFree);
         } catch (IOException ignored) {
         }


### PR DESCRIPTION
When running the cheat through Wayland, the client will try to grab the mouse cursor, which doesn't work on Wayland. Because of this the log is spammed and the cursor blinks all the time. This PR only tries to grab the mouse if GLFW platform is not Wayland.