### PR TITLE
Seperate creative mode settings for Reach

### DIFF
--- a/src/main/java/thunder/hack/features/modules/combat/Reach.java
+++ b/src/main/java/thunder/hack/features/modules/combat/Reach.java
@@ -10,6 +10,9 @@ public class Reach extends Module {
 
     public final Setting<Float> blocksRange = new Setting<>("BlocksRange", 3f, 0.1f, 10.0f);
     public final Setting<Float> entityRange = new Setting<>("EntityRange", 3f, 0.1f, 10.0f);
+    public final Setting<Boolean> Creative = new Setting<>("Creative", false);
+    public final Setting<Float> creativeBlocksRange = new Setting<>("CBlocksRange", 5f, 0.1f, 10.0f, v -> Creative.getValue());
+    public final Setting<Float> creativeEntityRange = new Setting<>("CBlocksRange", 5f, 0.1f, 10.0f, v -> Creative.getValue());
 
     @Override
     public String getDisplayInfo() {

--- a/src/main/java/thunder/hack/injection/MixinPlayerEntity.java
+++ b/src/main/java/thunder/hack/injection/MixinPlayerEntity.java
@@ -117,14 +117,24 @@ public class MixinPlayerEntity {
     @Inject(method = "getBlockInteractionRange", at = @At("HEAD"), cancellable = true)
     public void getBlockInteractionRangeHook(CallbackInfoReturnable<Double> cir) {
         if (ModuleManager.reach.isEnabled()) {
-            cir.setReturnValue((double) ModuleManager.reach.blocksRange.getValue());
+            if (ModuleManager.reach.Creative.getValue()) {
+                cir.setReturnValue((double) ModuleManager.reach.creativeBlocksRange.getValue());
+            }
+            else {
+                cir.setReturnValue((double) ModuleManager.reach.blocksRange.getValue());
+            }
         }
     }
 
     @Inject(method = "getEntityInteractionRange", at = @At("HEAD"), cancellable = true)
     public void getEntityInteractionRangeHook(CallbackInfoReturnable<Double> cir) {
         if (ModuleManager.reach.isEnabled()) {
-            cir.setReturnValue((double) ModuleManager.reach.entityRange.getValue());
+            if (ModuleManager.reach.Creative.getValue()) {
+                cir.setReturnValue((double) ModuleManager.reach.creativeEntityRange.getValue());
+            }
+            else {
+                cir.setReturnValue((double) ModuleManager.reach.entityRange.getValue());
+            }
         }
     }
 }

--- a/src/main/java/thunder/hack/injection/MixinPlayerEntity.java
+++ b/src/main/java/thunder/hack/injection/MixinPlayerEntity.java
@@ -117,7 +117,7 @@ public class MixinPlayerEntity {
     @Inject(method = "getBlockInteractionRange", at = @At("HEAD"), cancellable = true)
     public void getBlockInteractionRangeHook(CallbackInfoReturnable<Double> cir) {
         if (ModuleManager.reach.isEnabled()) {
-            if (ModuleManager.reach.Creative.getValue()) {
+            if (ModuleManager.reach.Creative.getValue() && mc.player.isCreative()) {
                 cir.setReturnValue((double) ModuleManager.reach.creativeBlocksRange.getValue());
             }
             else {
@@ -129,7 +129,7 @@ public class MixinPlayerEntity {
     @Inject(method = "getEntityInteractionRange", at = @At("HEAD"), cancellable = true)
     public void getEntityInteractionRangeHook(CallbackInfoReturnable<Double> cir) {
         if (ModuleManager.reach.isEnabled()) {
-            if (ModuleManager.reach.Creative.getValue()) {
+            if (ModuleManager.reach.Creative.getValue() && mc.player.isCreative()) {
                 cir.setReturnValue((double) ModuleManager.reach.creativeEntityRange.getValue());
             }
             else {


### PR DESCRIPTION
I tend to switch gamemodes very often, and when doing so, the reach setting vom blocksRange still applies, which is way too short for Creative.
This change addresses this and adds an extra option so creative reach can be configured independently. :)